### PR TITLE
add upload and download file interface

### DIFF
--- a/src/actions/nav.action.js
+++ b/src/actions/nav.action.js
@@ -32,6 +32,8 @@ const { nav } = createActions({
     backToDraw: () => null,
     changeCourseInfo: () => null,
     historyRecord: () => null,
+    uploadFile: () => null,
+    downloadFile: () => null,
     enterQuestion: id => QuizItemData[id].routeName,
   },
 })

--- a/src/components/CourseItemData.js
+++ b/src/components/CourseItemData.js
@@ -66,14 +66,14 @@ const CourseItemData = [
     title: ['檔案上傳'],
     imgSrc: [upload],
     user: 'teacher',
-    routeName: '',
+    routeName: 'UploadFile',
   },
   {
     id: 8,
     title: ['檔案下載'],
     imgSrc: [download],
     user: 'student',
-    routeName: '',
+    routeName: 'DownloadFile',
   },
   {
     id: 9,

--- a/src/components/styles/Button.styles.js
+++ b/src/components/styles/Button.styles.js
@@ -12,6 +12,7 @@ export default StyleSheet.create({
     padding: 10,
     borderRadius: 20,
     backgroundColor: '#3A8FB7',
+    width: '90%',
   },
   buttonLabel: {
     marginHorizontal: 20,

--- a/src/navigator/RootNavigator.js
+++ b/src/navigator/RootNavigator.js
@@ -11,6 +11,8 @@ import OnlinePeerList from '../pages/OnlinePeerList'
 import CourseInfo from '../pages/CourseInfo'
 import DrawLots from '../pages/DrawLots'
 import DrawFinish from '../pages/DrawLotsFinish'
+import UploadFile from '../pages/UploadFile'
+import DownloadFile from '../pages/DownloadFile'
 import Quiz from '../pages/Quiz/Quiz'
 import QuestionResult from '../pages/Quiz/QuestionResult'
 import Single from '../pages/Quiz/Single'
@@ -56,6 +58,12 @@ export default SwitchNavigator({
   },
   QuestionResult: {
     screen: QuestionResult,
+  },
+  UploadFile: {
+    screen: UploadFile,
+  },
+  DownloadFile: {
+    screen: DownloadFile,
   },
   Pages: DrawerNavigator({
     EditProfile: {

--- a/src/pages/DownloadFile.js
+++ b/src/pages/DownloadFile.js
@@ -1,0 +1,50 @@
+import React, { Component } from 'react'
+import { connect } from 'react-redux'
+import {
+  Text,
+  View,
+} from 'react-native'
+import PropTypes from 'prop-types'
+import styles from './styles/DownloadFile.styles'
+import navAction from '../actions/nav.action'
+import CloseImage from '../../asset/close.png'
+import Appbar from '../components/Appbar'
+
+
+const mapStateToProps = state => ({
+  ...state.fileDesc,
+})
+
+const mapDispatchToProps = dispatch => ({
+  navAction: {
+    openDrawer: () => { dispatch(navAction.openDrawer()) },
+    onExit: () => { dispatch(navAction.course()) },
+  },
+})
+
+class DownloadFile extends Component {
+  render() {
+    return (
+      <View style={styles.container}>
+        <Appbar title='檔案下載' withDrawer
+          rightIcon={CloseImage}
+          onRightPress={this.props.navAction.onExit}/>
+        <View style={styles.rowContainer}>
+          <Text style={styles.text}>歡迎進入檔案下載</Text>
+        </View>
+      </View>
+    )
+  }
+}
+
+// .propTypes  ~= constructor
+// course : proptypes.string,isRequired --> course 「必須」是string
+DownloadFile.propTypes = {
+  navAction: PropTypes.shape({
+    openDrawer: PropTypes.func.isRequired,
+    onExit: PropTypes.func.isRequired,
+  }).isRequired,
+}
+//  connect react component & redux store
+export default connect(mapStateToProps, mapDispatchToProps)(DownloadFile)
+

--- a/src/pages/UploadFile.js
+++ b/src/pages/UploadFile.js
@@ -1,0 +1,76 @@
+import React, { Component } from 'react'
+import { connect } from 'react-redux'
+import {
+  Text,
+  View,
+  TextInput,
+} from 'react-native'
+import PropTypes from 'prop-types'
+import styles from './styles/UploadFile.styles'
+import navAction from '../actions/nav.action'
+import CloseImage from '../../asset/close.png'
+import Button from '../components/Button'
+import Appbar from '../components/Appbar'
+
+
+const mapStateToProps = state => ({
+  ...state.fileDesc,
+})
+
+const mapDispatchToProps = dispatch => ({
+  navAction: {
+    openDrawer: () => { dispatch(navAction.openDrawer()) },
+    onExit: () => { dispatch(navAction.course()) },
+  },
+})
+
+class UploadFile extends Component {
+  constructor(props) {
+    super(props)
+    this.state = {
+      fileDesc: '這是這次上課會用到的檔案 =)',
+    }
+    this.onPressUpload = this.onPressUpload.bind(this)
+    this.onPressChoose = this.onPressChoose.bind(this)
+  }
+  onPressUpload = () => {
+  }
+  onPressChoose = () => {
+  }
+  render() {
+    return (
+      <View style={styles.container}>
+        <Appbar title='檔案上傳' withDrawer
+          rightIcon={CloseImage}
+          onRightPress={this.props.navAction.onExit}/>
+        <View style={styles.rowContainer}>
+          <Text style={styles.text}>檔案描述</Text>
+          <TextInput
+            style={styles.input}
+            onChangeText={(fileDesc) => { this.setState({ fileDesc }) }}
+            value={this.state.fileDesc}
+            multiline={true}
+            numberOfLines={3}
+          />
+          <View style={styles.empty}/>
+          <View style={styles.buttonContainer}>
+            <Button label='選擇檔案' onPress={this.onPressChoose}/>
+            <Button label='上傳' onPress={this.onPressUpload}/>
+          </View>
+        </View>
+      </View>
+    )
+  }
+}
+
+// .propTypes  ~= constructor
+// course : proptypes.string,isRequired --> course 「必須」是string
+UploadFile.propTypes = {
+  navAction: PropTypes.shape({
+    openDrawer: PropTypes.func.isRequired,
+    onExit: PropTypes.func.isRequired,
+  }).isRequired,
+}
+//  connect react component & redux store
+export default connect(mapStateToProps, mapDispatchToProps)(UploadFile)
+

--- a/src/pages/styles/DownloadFile.styles.js
+++ b/src/pages/styles/DownloadFile.styles.js
@@ -1,0 +1,47 @@
+import { StyleSheet } from 'react-native'
+
+export default StyleSheet.create({
+  container: {
+    paddingTop: 20,
+    flex: 1,
+    backgroundColor: '#3A8FB7',
+  },
+  rowContainer: {
+    flex: 1,
+    alignItems: 'stretch',
+    padding: 15,
+    flexDirection: 'column',
+    marginTop: 15,
+    backgroundColor: 'white',
+  },
+  buttonContainer: {
+    flexDirection: 'column',
+    flex: 1,
+    alignItems: 'stretch',
+    marginBottom: 10,
+    paddingTop: 5,
+    width: '100%',
+  },
+  text: {
+    paddingTop: 16,
+    paddingLeft: 10,
+    textAlign: 'center',
+    marginVertical: '60%',
+    marginHorizontal: 5,
+    color: '#3A8FB7',
+    fontFamily: 'Avenir',
+    fontSize: 22,
+  },
+  input: {
+    height: 150,
+    paddingVertical: 6,
+    paddingHorizontal: 10,
+    margin: 10,
+    borderColor: '#3A8FB7',
+    borderWidth: 1.7,
+    borderRadius: 10,
+    color: 'black',
+    fontFamily: 'Avenir',
+    fontSize: 18,
+  },
+})

--- a/src/pages/styles/UploadFile.styles.js
+++ b/src/pages/styles/UploadFile.styles.js
@@ -1,0 +1,50 @@
+import { StyleSheet } from 'react-native'
+
+export default StyleSheet.create({
+  container: {
+    paddingTop: 20,
+    flex: 1,
+    backgroundColor: '#3A8FB7',
+  },
+  rowContainer: {
+    flex: 1,
+    alignItems: 'stretch',
+    padding: 15,
+    flexDirection: 'column',
+    marginTop: 15,
+    backgroundColor: 'white',
+  },
+  empty: {
+    height: 70,
+    flexDirection: 'column',
+    backgroundColor: 'white',
+  },
+  buttonContainer: {
+    flexDirection: 'column',
+    flex: 1,
+    alignItems: 'stretch',
+    marginBottom: 10,
+    paddingTop: 5,
+    width: '100%',
+  },
+  text: {
+    paddingTop: 16,
+    paddingLeft: 10,
+    marginHorizontal: 5,
+    color: '#3A8FB7',
+    fontFamily: 'Avenir',
+    fontSize: 22,
+  },
+  input: {
+    height: 150,
+    paddingVertical: 10,
+    paddingHorizontal: 10,
+    margin: 10,
+    borderColor: '#3A8FB7',
+    borderWidth: 1.7,
+    borderRadius: 10,
+    color: 'black',
+    fontFamily: 'Avenir',
+    fontSize: 18,
+  },
+})

--- a/src/reducers/uploadFile.js
+++ b/src/reducers/uploadFile.js
@@ -1,0 +1,14 @@
+const initialState = {
+  fileDesc: '',
+}
+
+const reducerMap = {
+  initialize: state => ({
+    ...state,
+    uploadFile: {
+      fileDesc: '',
+    },
+  }),
+}
+
+export default { reducerMap, initialState }


### PR DESCRIPTION
# Features
1. Open Upload File interface after pressing upload file menu (teacher)
2. Open Download File interface after pressing download file menu (student)
3. Close the interface when pressing 'X' button

# Test Plans
* [x] Using the simulator

# Known Issues

# To-do
* [ ] Design icons

# Screenshot
Upload interface (Teacher)
![simulator screen shot - iphone 6 - 2018-05-31 at 02 34 33](https://user-images.githubusercontent.com/9104658/40895994-09bb3efc-67e5-11e8-8e26-67df65263927.png)
Download interface (Student) *using existing icon (not the real icon)*
![simulator screen shot - iphone 6 - 2018-05-31 at 02 35 08](https://user-images.githubusercontent.com/9104658/40895996-0b6061a6-67e5-11e8-9720-a6d55cf13bd9.png)